### PR TITLE
Use new quant-cloud-init-action workflow.

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -23,44 +23,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Set up environment variables
-        id: vars
-        run: |
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            # For tags, use the tag name
-            TAG=${GITHUB_REF#refs/tags/}
-            echo "suffix=-${TAG}" >> $GITHUB_OUTPUT
-          elif [[ $GITHUB_REF == refs/heads/develop ]]; then
-            # For develop branch, use -staging suffix
-            echo "suffix=-staging" >> $GITHUB_OUTPUT
-            echo "environment=staging" >> $GITHUB_OUTPUT
-          elif [[ $GITHUB_REF == refs/heads/main ]]; then
-            # For main branch, use -latest suffix
-            echo "suffix=-latest" >> $GITHUB_OUTPUT
-            echo "environment=production" >> $GITHUB_OUTPUT
-          else
-            echo "Error: Unknown branch or tag ref: $GITHUB_REF"
-            exit 1
-          fi
-
-      - name: Get ECR Credentials
-        uses: quantcdn/quant-cloud-ecr-action@v1
-        id: ecr-login
+      - name: Initialize Quant Cloud
+        uses: quantcdn/quant-cloud-init-action@v1
+        id: init
         with:
-          api_key: ${{ secrets.QUANT_API_KEY }}
-          organization: ${{ secrets.QUANT_ORGANIZATION }}
-
-      - name: Login to ECR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ steps.ecr-login.outputs.endpoint }}
-          username: ${{ steps.ecr-login.outputs.username }}
-          password: ${{ steps.ecr-login.outputs.password }}
-
-      - name: Strip protocol from ECR endpoint
-        id: ecr-endpoint-stripped
-        run: |
-          echo "stripped_endpoint=$(echo '${{ steps.ecr-login.outputs.endpoint }}' | sed -E 's|^https?://||')" >> $GITHUB_OUTPUT
+          quant_organization: ${{ secrets.QUANT_ORGANIZATION }}
+          quant_api_key: ${{ secrets.QUANT_API_KEY }}
 
       - name: Build and push WordPress image
         uses: docker/build-push-action@v5
@@ -68,8 +36,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ steps.ecr-endpoint-stripped.outputs.stripped_endpoint }}/${{ secrets.QUANT_ORGANIZATION }}/${{ secrets.QUANT_APPLICATION }}:wordpress${{ steps.vars.outputs.suffix }}
+          tags: ${{ steps.init.outputs.stripped_endpoint }}/${{ secrets.QUANT_ORGANIZATION }}/${{ steps.init.outputs.quant_application }}:wordpress${{ steps.init.outputs.image_suffix }}
           cache-from: |
             type=gha
             type=registry,ref=ghcr.io/quantcdn-templates/app-wordpress:cache
@@ -81,6 +48,6 @@ jobs:
         with:
           api_key: ${{ secrets.QUANT_API_KEY }}
           organization: ${{ secrets.QUANT_ORGANIZATION }}
-          application: ${{ secrets.QUANT_APPLICATION }}
-          environment: ${{ steps.vars.outputs.environment }}
+          application: ${{ steps.init.outputs.quant_application }}
+          environment: ${{ steps.init.outputs.environment_name }}
           action: redeploy 


### PR DESCRIPTION
This uses the new GitHub action designed to simplify pipelines with the new init action https://github.com/marketplace/actions/quant-cloud-init

The init action now takes care of
* validating quant org/token
* logging in to image registry
* autogenerating image tag suffixes based on branch/tag
* autogenerating environment names based on branch
