### PR TITLE
Update php and readme, and override warnings.

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -32,13 +32,13 @@ jobs:
       matrix:
         php_version: ['7.4-dev', '8.2-dev', '8.3-dev', '8.4-dev']
         include:
+          - php_version: '7.4-dev'
+            is_default: false
           - php_version: '8.2-dev' 
-            is_default: true
-          - php_version: '8.4-dev'
             is_default: false
           - php_version: '8.3-dev'
-            is_default: false
-          - php_version: '7.4-dev'
+            is_default: true
+          - php_version: '8.4-dev'
             is_default: false
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,13 @@ jobs:
       matrix:
         php_version: ['7.4', '8.2', '8.3', '8.4']
         include:
+          - php_version: '7.4'
+            is_default: false
           - php_version: '8.2' 
-            is_default: true
-          - php_version: '8.4'
             is_default: false
           - php_version: '8.3'
-            is_default: false
-          - php_version: '7.4'
+            is_default: true
+          - php_version: '8.4'
             is_default: false
 
     steps:
@@ -195,4 +195,4 @@ jobs:
             TAGS_DISPLAY="$TAGS_DISPLAY, \`latest\`"
           fi
           echo "- **Tags**: $TAGS_DISPLAY" >> $GITHUB_STEP_SUMMARY
-          echo "- **Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY 
+          echo "- **Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ WP-CLI automatically inherits the environment variables and database configurati
    - For docker compose, you may see `ports are not available` errors
    - If you are running DDEV, turn it off with `ddev poweroff`
    - If you are running another app, turn it off with `docker compose -p app-name down`
+   - If using DDEV after docker compose, you will need to turn off the app with the same port or run `docker compose stop`
 
 1. **Restarting Local**
 

--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ For both deployment options, you can develop locally using either Docker Compose
    > **Note**: This override enables testing of entrypoint scripts (like `00-set-document-root.sh`) that normally run via Quant Cloud's platform wrapper. Required for proper local development environment.
 1. **Start services**:
    ```bash
-   docker-compose up -d
+   docker compose up -d
    ```
 1. **Access WordPress** at http://localhost and run through installation
 1. **Add Standard Plugins and Themes**
    ```bash
-   docker-compose exec wordpress wp plugin install quant --activate --allow-root
-   docker-compose exec wordpress wp theme install twentytwentyfive --activate --allow-root
+   docker compose exec wordpress wp plugin install quant --activate --allow-root
+   docker compose exec wordpress wp theme install twentytwentyfive --activate --allow-root
    ```
 
 ### Option 2: DDEV (Recommended for Developers)
@@ -153,9 +153,9 @@ This template includes WP-CLI (WordPress Command Line Interface) pre-installed a
 
 **Docker Compose**
 ```bash
-docker-compose exec wordpress wp --info --allow-root
-docker-compose exec wordpress wp core version --allow-root
-docker-compose exec wordpress wp plugin list --allow-root
+docker compose exec wordpress wp --info --allow-root
+docker compose exec wordpress wp core version --allow-root
+docker compose exec wordpress wp plugin list --allow-root
 ```
 
 **DDEV**
@@ -205,8 +205,8 @@ WP-CLI automatically inherits the environment variables and database configurati
 
 **Docker Compose**
 ```bash
-docker-compose down -v
-docker-compose up -d
+docker compose down -v
+docker compose up -d
 
 `**DDEV**
 ```bash
@@ -224,7 +224,7 @@ View container logs:
 
 **Docker Compose**
 ```bash
-docker-compose logs -f wordpress
+docker compose logs -f wordpress
 ```
 
 **DDEV**

--- a/README.md
+++ b/README.md
@@ -201,6 +201,11 @@ WP-CLI automatically inherits the environment variables and database configurati
    - Verify Apache is running
    - Check resource limits
 
+1. **Port Conflicts**
+   - For docker compose, you may see `ports are not available` errors
+   - If you are running DDEV, turn it off with `ddev poweroff`
+   - If you are running another app, turn it off with `docker compose -p app-name down`
+
 1. **Restarting Local**
 
 **Docker Compose**

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For both deployment options, you can develop locally using either Docker Compose
 1. **Clone** your repo (or this template)
 1. **Use overrides** (required for local development):
    ```bash
-   docker-compose.override.yml
+   ls docker-compose.override.yml
    ```
    > **Note**: This override enables testing of entrypoint scripts (like `00-set-document-root.sh`) that normally run via Quant Cloud's platform wrapper. Required for proper local development environment.
 1. **Start services**:
@@ -170,6 +170,7 @@ ddev wp plugin list
 ```bash
 wp --info --allow-root
 wp core version --allow-root
+wp plugin list --allow-root
 wp plugin install akismet quant --activate --allow-root
 wp theme install twentytwentyfive --activate --allow-root
 ```

--- a/mu-plugins/quant-site-health.php
+++ b/mu-plugins/quant-site-health.php
@@ -14,10 +14,17 @@ if (!defined('ABSPATH')) {
  * Customize Site Health tests for Quant Cloud environment
  */
 add_filter('site_status_tests', function($tests) {
-    // Replace the page_cache async test
+    // Remove the async page_cache test and add our own as a direct test
+    // (async tests use AJAX callbacks which are more complex to override)
     if (isset($tests['async']['page_cache'])) {
-        $tests['async']['page_cache']['test'] = 'quant_test_page_cache';
+        unset($tests['async']['page_cache']);
     }
+
+    // Add our page cache test as a direct test so it shows in results
+    $tests['direct']['quant_page_cache'] = [
+        'label' => __('Page Cache'),
+        'test'  => 'quant_test_page_cache',
+    ];
 
     // Replace plugin_version direct test (handles inactive plugins warning)
     if (isset($tests['direct']['plugin_version'])) {

--- a/mu-plugins/quant-site-health.php
+++ b/mu-plugins/quant-site-health.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Plugin Name: Quant Site Health Customizations
+ * Description: Customize Site Health checks for Quant Cloud environment
+ * Version: 1.0.0
+ */
+
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Customize Site Health tests for Quant Cloud environment
+ */
+add_filter('site_status_tests', function($tests) {
+    // Replace the page_cache async test
+    if (isset($tests['async']['page_cache'])) {
+        $tests['async']['page_cache']['test'] = 'quant_test_page_cache';
+    }
+
+    // Replace plugin_version direct test (handles inactive plugins warning)
+    if (isset($tests['direct']['plugin_version'])) {
+        $tests['direct']['plugin_version']['test'] = 'quant_test_plugin_version';
+    }
+
+    // Replace theme_version direct test (handles inactive themes warning)
+    if (isset($tests['direct']['theme_version'])) {
+        $tests['direct']['theme_version']['test'] = 'quant_test_theme_version';
+    }
+
+    return $tests;
+});
+
+/**
+ * Custom page cache test - explains Quant CDN handles caching
+ */
+function quant_test_page_cache() {
+    return [
+        'label'       => __('Page caching is handled by QuantCDN'),
+        'status'      => 'good',
+        'badge'       => [
+            'label' => __('Performance'),
+            'color' => 'blue',
+        ],
+        'description' => sprintf(
+            '<p>%s</p>',
+            __('This site is hosted on Quant Cloud, which provides edge caching through its global CDN. Server-side page caching plugins are not needed.')
+        ),
+        'actions'     => '',
+        'test'        => 'page_cache',
+    ];
+}
+
+/**
+ * Custom plugin version test - runs default check but suppresses inactive plugin warning
+ * only if the inactive plugins are the default WordPress bundled plugins (Hello Dolly, Akismet)
+ */
+function quant_test_plugin_version() {
+    // Run the original test
+    $site_health = WP_Site_Health::get_instance();
+    $result = $site_health->get_test_plugin_version();
+
+    // If the issue is about inactive plugins, check if they're only default WP plugins
+    if ($result['status'] === 'recommended' && 
+        strpos($result['label'], 'inactive') !== false) {
+        
+        // Get list of inactive plugins
+        $all_plugins = get_plugins();
+        $active_plugins = get_option('active_plugins', []);
+        $inactive_plugins = array_diff(array_keys($all_plugins), $active_plugins);
+        
+        // Default WordPress bundled plugins (by directory/file path)
+        $default_wp_plugins = [
+            'hello.php',           // Hello Dolly (single file in plugins root)
+            'akismet/akismet.php', // Akismet
+        ];
+        
+        // Check if all inactive plugins are default WP plugins
+        $only_default_inactive = true;
+        foreach ($inactive_plugins as $plugin) {
+            if (!in_array($plugin, $default_wp_plugins, true)) {
+                $only_default_inactive = false;
+                break;
+            }
+        }
+        
+        // Only suppress warning if all inactive plugins are default WP plugins
+        if ($only_default_inactive) {
+            $result['status'] = 'good';
+            $result['label'] = __('Plugins are properly configured');
+            $result['description'] = sprintf(
+                '<p>%s</p>',
+                __('Your plugins are up to date. The bundled WordPress plugins (Hello Dolly, Akismet) are available if needed but can remain inactive.')
+            );
+        }
+    }
+
+    return $result;
+}
+
+/**
+ * Custom theme version test - runs default check but suppresses inactive theme warning
+ * only if the inactive themes are the default WordPress bundled themes (twentytwenty*)
+ */
+function quant_test_theme_version() {
+    // Run the original test
+    $site_health = WP_Site_Health::get_instance();
+    $result = $site_health->get_test_theme_version();
+
+    // If the issue is about inactive themes, check if they're only default WP themes
+    if ($result['status'] === 'recommended' && 
+        strpos($result['label'], 'inactive') !== false) {
+        
+        // Get list of all themes and the active theme
+        $all_themes = wp_get_themes();
+        $active_theme = wp_get_theme();
+        $active_stylesheet = $active_theme->get_stylesheet();
+        
+        // Check if all inactive themes are default WordPress themes (twentytwenty*)
+        $only_default_inactive = true;
+        foreach ($all_themes as $stylesheet => $theme) {
+            // Skip the active theme
+            if ($stylesheet === $active_stylesheet) {
+                continue;
+            }
+            
+            // Check if this inactive theme is a default WordPress theme
+            // Default themes follow the pattern: twentytwenty, twentytwentyone, twentytwentytwo, etc.
+            if (!preg_match('/^twentytwenty/', $stylesheet)) {
+                $only_default_inactive = false;
+                break;
+            }
+        }
+        
+        // Only suppress warning if all inactive themes are default WP themes
+        if ($only_default_inactive) {
+            $result['status'] = 'good';
+            $result['label'] = __('Themes are properly configured');
+            $result['description'] = sprintf(
+                '<p>%s</p>',
+                __('Your active theme is up to date. The bundled WordPress themes serve as fallbacks and can remain inactive.')
+            );
+        }
+    }
+
+    return $result;
+}

--- a/mu-plugins/quant-site-health.php
+++ b/mu-plugins/quant-site-health.php
@@ -62,20 +62,20 @@ function quant_test_plugin_version() {
     $result = $site_health->get_test_plugin_version();
 
     // If the issue is about inactive plugins, check if they're only default WP plugins
-    if ($result['status'] === 'recommended' && 
+    if ($result['status'] === 'recommended' &&
         strpos($result['label'], 'inactive') !== false) {
-        
+
         // Get list of inactive plugins
         $all_plugins = get_plugins();
         $active_plugins = get_option('active_plugins', []);
         $inactive_plugins = array_diff(array_keys($all_plugins), $active_plugins);
-        
+
         // Default WordPress bundled plugins (by directory/file path)
         $default_wp_plugins = [
             'hello.php',           // Hello Dolly (single file in plugins root)
             'akismet/akismet.php', // Akismet
         ];
-        
+
         // Check if all inactive plugins are default WP plugins
         $only_default_inactive = true;
         foreach ($inactive_plugins as $plugin) {
@@ -84,7 +84,7 @@ function quant_test_plugin_version() {
                 break;
             }
         }
-        
+
         // Only suppress warning if all inactive plugins are default WP plugins
         if ($only_default_inactive) {
             $result['status'] = 'good';
@@ -109,14 +109,14 @@ function quant_test_theme_version() {
     $result = $site_health->get_test_theme_version();
 
     // If the issue is about inactive themes, check if they're only default WP themes
-    if ($result['status'] === 'recommended' && 
+    if ($result['status'] === 'recommended' &&
         strpos($result['label'], 'inactive') !== false) {
-        
+
         // Get list of all themes and the active theme
         $all_themes = wp_get_themes();
         $active_theme = wp_get_theme();
         $active_stylesheet = $active_theme->get_stylesheet();
-        
+
         // Check if all inactive themes are default WordPress themes (twentytwenty*)
         $only_default_inactive = true;
         foreach ($all_themes as $stylesheet => $theme) {
@@ -124,7 +124,7 @@ function quant_test_theme_version() {
             if ($stylesheet === $active_stylesheet) {
                 continue;
             }
-            
+
             // Check if this inactive theme is a default WordPress theme
             // Default themes follow the pattern: twentytwenty, twentytwentyone, twentytwentytwo, etc.
             if (!preg_match('/^twentytwenty/', $stylesheet)) {
@@ -132,7 +132,7 @@ function quant_test_theme_version() {
                 break;
             }
         }
-        
+
         // Only suppress warning if all inactive themes are default WP themes
         if ($only_default_inactive) {
             $result['status'] = 'good';


### PR DESCRIPTION
## Summary

- Update to PHP 8.3 to avoid warning
- Add custom mu-plugin to:
-- Not show plugin/theme warnings when it's for default WP plugins/themes
-- Don't warn about page-cache since CDN is in place
- Minor README.md updates

## Checklist

- [x] CI green (build/lint/tests)
- [x] Updated README/docs if needed

## Before

<img width="2016" height="3454" alt="screencapture-production-kristentesting-wordpress-apps-quantgovsites-wp-admin-site-health-php-2026-01-24-13_38_44" src="https://github.com/user-attachments/assets/0c8a3c9b-e0f1-4ea6-a0fb-1b5811f85cf5" />

## After

<img width="847" height="763" alt="Screenshot 2026-01-24 at 1 31 46 PM" src="https://github.com/user-attachments/assets/19b280bb-a0af-46ac-8881-c1dfa8d97148" />

<img width="828" height="142" alt="Screenshot 2026-01-24 at 1 31 53 PM" src="https://github.com/user-attachments/assets/3431874a-6230-4ad0-ad07-583be90b02c5" />
